### PR TITLE
Implemented setup.py to allow PIP installations, also fixed PIL imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup
+
+setup(
+    name='svt',
+    version='1.1',
+    author='Luis J. Villanueva',
+    author_email='coquipr.com@gmail.com',
+    url='https://github.com/ljvillanueva/Sound-Viewer-Tool',
+
+    description='Generate waveform and spectrogram png images from a wav file',
+    long_description='This Python script uses the numpy and audiolab modules to generate waveform and spectrogram png images from a wav file. It is based on a script by Freesound.org.',
+
+    install_requires=[
+        'numpy>=1.1',
+        'scikits.audiolab>=0.8',
+        'Pillow',
+    ],
+
+    platforms='any',
+    keywords=['audio'],
+    license='GPL3',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Topic :: Multimedia :: Sound/Audio'
+    ],
+    scripts=['svt.py'],
+)

--- a/svt.py
+++ b/svt.py
@@ -27,7 +27,7 @@ svt_version = "1.1"
  
 import optparse, math, sys
 import scikits.audiolab as audiolab
-import ImageFilter, ImageChops, Image, ImageDraw, ImageColor
+from PIL import ImageFilter, ImageChops, Image, ImageDraw, ImageColor
 import numpy
  
 class TestAudioFile(object):
@@ -586,4 +586,3 @@ if __name__ == '__main__':
 	    create_png(*args)
     else:
         print "\nsvt version " + str(svt_version) + "\n"
-


### PR DESCRIPTION
This PR implements a very basic `setup.py` file to allow PIP installations, like

```
pip install git+https://github.com/ljvillanueva/Sound-Viewer-Tool.git#egg=svt
```

After doing that, `svt.py` is accessible from anywhere in your system (provided $PATH is set). You could also upload the package to PyPI and get the additional comfort of just doing

```
pip install svt
```

Also, `setup.py` specifically names the requirements for your tool. This enables PIP to fully automatically install svt and all its dependencies (numpy, PIL and scikits.audiolab), provided they haven't been installed using `apt-get` of course.
